### PR TITLE
chore: Temporarily remove notify-failure job for debugging YAML

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -84,16 +84,6 @@ jobs:
         if: secrets.GITHUB_ACTIONS_SIGNING_KEY_BASE64 == ''
         run: echo "::warning:: Keystore secret (GITHUB_ACTIONS_SIGNING_KEY_BASE64) not found. APK will not be signed or will fail at signing if signing is mandatory."
 
-  notify-failure:
-    name: Notify on Failure
-    runs-on: ubuntu-latest
-    if: failure() && github.event_name == 'push' # S'exécute seulement si un job précédent a échoué et que c'est un push
-    steps:
-      - name: Send Failure Notification (Example)
-        run: echo "::error:: Le build de l'APK a échoué pour le commit ${{ github.sha }} sur la branche ${{ github.ref_name }}."
-        # Ici, vous pourriez intégrer une action pour envoyer une notification Slack, email, etc.
-        # Par exemple, en utilisant une action du Marketplace.
-
 # Instructions pour configurer les secrets GitHub (à faire dans les paramètres du dépôt > Secrets and variables > Actions):
 # 1. GITHUB_ACTIONS_SIGNING_KEY_BASE64:
 #    - Sur votre machine locale, où vous avez votre fichier `my-release-key.keystore`:


### PR DESCRIPTION
This commit removes the `notify-failure` job to help isolate a YAML syntax error in the GitHub Actions workflow file.

fix: Correct YAML syntax in GitHub Actions workflow

Simplifies comments in the GitHub Actions workflow file to prevent potential YAML parsing issues.

feat: Implement Rock Paper Scissors game with Android APK generation workflow

Implements a simple Rock Paper Scissors game in React Native.

Features:
- Player can choose Rock, Paper, or Scissors.
- Computer makes a random choice.
- Displays round results (Win, Lose, Tie).
- Score counter for player and computer.
- Reset button for the game.
- Displays player and computer choices.

Technical Details:
- Uses React Native functional components and hooks.
- Simple UI styled with StyleSheet.
- Correct game logic.
- Clean and commented code.

Deliverables:
- Complete code for App.js.
- GitHub Actions workflow (.github/workflows/android-ci.yml) for automated APK building.
- Explanation of the code, testing steps, and APK generation instructions.
- Suggestion for optional improvement (AsyncStorage for score persistence).