### PR TITLE
refactor: Align GitHub Actions workflow structure with best practices

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -2,81 +2,75 @@ name: Android CI - Build APK
 
 on:
   push:
-    branches: [ "main", "master" ] # Déclencher sur push vers main ou master
+    branches: [ "main", "master" ]
   pull_request:
-    branches: [ "main", "master" ] # Déclencher aussi sur les Pull Requests vers main ou master
+    branches: [ "main", "master" ]
 
-jobs:
-  build-apk:
+jobs: # Clé de premier niveau
+  build-apk: # Premier job, indenté de 2 espaces
     name: Build Release APK
     runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
+    steps: # Propriété de build-apk, indentée de 2 espaces par rapport à build-apk (4 au total)
+      - name: Checkout repository # Étape, commence par un tiret et est indentée de 2 espaces par rapport à steps (6 au total)
         uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
-        with:
-          java-version: '17' # React Native nécessite généralement une version spécifique du JDK
-          distribution: 'temurin' # Distribution populaire du JDK
+        with: # Propriété de l'étape, indentée de 2 espaces par rapport au tiret (8 au total)
+          java-version: '17'
+          distribution: 'temurin'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18' # Choisissez une version LTS de Node.js compatible
-          cache: 'npm' # Mettre en cache les dépendances npm
+          node-version: '18'
+          cache: 'npm'
 
       - name: Install npm dependencies
         run: npm install
 
-      # Crée un fichier keystore à partir d'un secret GitHub encodé en Base64
-      # Le secret GITHUB_ACTIONS_SIGNING_KEY_BASE64 doit contenir le fichier .keystore encodé en base64
-      # Vous pouvez générer cette chaîne avec la commande : base64 -w 0 my-release-key.keystore
       - name: Decode Keystore
-        if: secrets.GITHUB_ACTIONS_SIGNING_KEY_BASE64 != '' # Ne s'exécute que si le secret est défini
+        if: secrets.GITHUB_ACTIONS_SIGNING_KEY_BASE64 != ''
         env:
           SIGNING_KEY_BASE64: ${{ secrets.GITHUB_ACTIONS_SIGNING_KEY_BASE64 }}
         run: |
           echo $SIGNING_KEY_BASE64 | base64 --decode > android/app/my-release-key.keystore
           echo "Keystore decoded successfully."
 
-      # Créer le fichier gradle.properties avec les informations de signature à partir des secrets GitHub
-      # Ces secrets doivent être configurés dans les paramètres du dépôt GitHub :
-      # GITHUB_ACTIONS_KEY_ALIAS, GITHUB_ACTIONS_KEY_PASSWORD, GITHUB_ACTIONS_STORE_PASSWORD
       - name: Create gradle.properties for signing
-        if: secrets.GITHUB_ACTIONS_SIGNING_KEY_BASE64 != '' # Ne s'exécute que si le secret est défini
+        if: secrets.GITHUB_ACTIONS_SIGNING_KEY_BASE64 != ''
+        # working-directory: ./ # Commenté car peut-être source d'erreur si non nécessaire explicitement
         run: |
           echo "MYAPP_RELEASE_STORE_FILE=my-release-key.keystore" > android/gradle.properties
           echo "MYAPP_RELEASE_KEY_ALIAS=${{ secrets.GITHUB_ACTIONS_KEY_ALIAS }}" >> android/gradle.properties
           echo "MYAPP_RELEASE_STORE_PASSWORD=${{ secrets.GITHUB_ACTIONS_STORE_PASSWORD }}" >> android/gradle.properties
           echo "MYAPP_RELEASE_KEY_PASSWORD=${{ secrets.GITHUB_ACTIONS_KEY_PASSWORD }}" >> android/gradle.properties
           echo "Gradle properties for signing created."
-        working-directory: ./ # S'assurer que le chemin vers android/gradle.properties est correct
 
       - name: Give gradlew execution permission
+        # working-directory: ./ # Commenté
         run: chmod +x android/gradlew
-        working-directory: ./
 
       - name: Build Release APK
+        working-directory: ./android # Nécessaire ici pour exécuter gradlew dans le bon dossier
         run: ./gradlew assembleRelease
-        working-directory: ./android
 
       - name: Upload Release APK Artifact
         uses: actions/upload-artifact@v4
         with:
           name: RockPaperScissors-release-apk
           path: android/app/build/outputs/apk/release/app-release.apk
-          if-no-files-found: error # Fait échouer le workflow si l'APK n'est pas trouvé
+          if-no-files-found: error
 
       - name: Notify if Keystore secret is missing (Optional)
         if: secrets.GITHUB_ACTIONS_SIGNING_KEY_BASE64 == ''
         run: echo "::warning:: Keystore secret (GITHUB_ACTIONS_SIGNING_KEY_BASE64) not found. APK will not be signed or will fail at signing if signing is mandatory."
 
-  notify-failure:
+  notify-failure: # Second job, indenté de 2 espaces, au même niveau que build-apk
     name: Notify on Failure
     runs-on: ubuntu-latest
     if: failure() && github.event_name == 'push' # S'exécute seulement si un job précédent a échoué et que c'est un push
+    needs: build-apk # Ajout suggéré pour la dépendance logique
     steps:
       - name: Send Failure Notification (Example)
         run: echo "::error:: Le build de l'APK a échoué pour le commit ${{ github.sha }} sur la branche ${{ github.ref_name }}."
@@ -84,6 +78,7 @@ jobs:
         # Par exemple, en utilisant une action du Marketplace.
 
 # Instructions pour configurer les secrets GitHub (à faire dans les paramètres du dépôt > Secrets and variables > Actions):
+# ... (le reste des commentaires reste identique)
 # 1. GITHUB_ACTIONS_SIGNING_KEY_BASE64:
 #    - Sur votre machine locale, où vous avez votre fichier `my-release-key.keystore`:
 #      `base64 -w 0 my-release-key.keystore` (Linux/macOS)
@@ -112,5 +107,4 @@ jobs:
 # Node 18 est une version LTS actuelle.
 #
 # Le `working-directory: ./android` pour la tâche `Build Release APK` est crucial.
-# Le `working-directory: ./` pour `Create gradle.properties for signing` est utilisé pour que le chemin `android/gradle.properties` soit correct.
 # `chmod +x android/gradlew` est nécessaire car le script gradlew pourrait ne pas avoir les permissions d'exécution après le checkout.


### PR DESCRIPTION
Restructures the .github/workflows/android-ci.yml file to strictly follow YAML indentation and structure conventions for GitHub Actions, based on a working example (amirisback/automated-build-android-app-with-github-action) and previous feedback.

Key changes:
- Ensures `jobs` is a top-level key.
- Correctly indents `build-apk` and `notify-failure` jobs as direct children of `jobs` with identical indentation.
- Standardizes indentation for job properties (`name`, `runs-on`, `steps`, etc.) and step properties (`uses`, `with`, `run`, etc.).
- Adds `needs: build-apk` to the `notify-failure` job for logical dependency.
- Removes potentially redundant `working-directory: ./` where default behavior is sufficient.

This aims to resolve persistent YAML syntax errors.

style: Verify and confirm correct indentation for jobs in GitHub Actions workflow

Confirms that `build-apk` and `notify-failure` jobs are correctly indented under the `jobs` key, at the same indentation level. This is based on a re-read of the file and previous feedback, ensuring standard YAML structure for GitHub Actions.

fix: Ensure correct indentation for notify-failure job in GitHub Actions workflow

Verifies and corrects the indentation for the `notify-failure` job and its properties to ensure it is correctly aligned under the `jobs` key, at the same level as `build-apk`. Removes an explanatory comment that might have interfered with parsing.

fix: Correct placement of if-no-files-found in GitHub Actions workflow

Ensures `if-no-files-found` is correctly placed under `with:` for the `actions/upload-artifact@v4` step, according to the action's documentation.

fix: Correct indentation for if-no-files-found in GitHub Actions workflow

Adjusts the indentation of `if-no-files-found` to be a parameter of the `actions/upload-artifact@v4` step, not a sub-property of `with:`.

This addresses a YAML syntax error.

chore: Temporarily remove notify-failure job for debugging YAML

This commit removes the `notify-failure` job to help isolate a YAML syntax error in the GitHub Actions workflow file.

fix: Correct YAML syntax in GitHub Actions workflow

Simplifies comments in the GitHub Actions workflow file to prevent potential YAML parsing issues.

feat: Implement Rock Paper Scissors game with Android APK generation workflow

Implements a simple Rock Paper Scissors game in React Native.

Features:
- Player can choose Rock, Paper, or Scissors.
- Computer makes a random choice.
- Displays round results (Win, Lose, Tie).
- Score counter for player and computer.
- Reset button for the game.
- Displays player and computer choices.

Technical Details:
- Uses React Native functional components and hooks.
- Simple UI styled with StyleSheet.
- Correct game logic.
- Clean and commented code.

Deliverables:
- Complete code for App.js.
- GitHub Actions workflow (.github/workflows/android-ci.yml) for automated APK building.
- Explanation of the code, testing steps, and APK generation instructions.
- Suggestion for optional improvement (AsyncStorage for score persistence).