### PR TITLE
fix: Update Kotlin version to 1.8.20

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 34
         targetSdkVersion = 34
         ndkVersion = "25.1.8937393"
-        kotlinVersion = "1.8.0"
+        kotlinVersion = "1.8.20" // Updated to align with RN 0.73.x recommendations
     }
     repositories {
         google()


### PR DESCRIPTION
- Updated kotlinVersion in `android/build.gradle` from `1.8.0` to `1.8.20`.
- This change aims to resolve compilation issues with `react-native-gesture-handler` by aligning the Kotlin version with React Native 0.73.x recommendations.