### PR TITLE
fix: Downgrade react-native-gesture-handler to ~2.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@react-navigation/native": "^7.1.14",
         "react": "18.2.0",
         "react-native": "0.73.6",
-        "react-native-gesture-handler": "^2.27.1",
+        "react-native-gesture-handler": "~2.16.0",
         "react-native-reanimated": "~3.6.2",
         "react-native-safe-area-context": "^5.5.1",
         "react-native-screens": "^4.11.1"
@@ -8463,8 +8463,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -10123,14 +10122,16 @@
       }
     },
     "node_modules/react-native-gesture-handler": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.27.1.tgz",
-      "integrity": "sha512-57TUWerhdz589OcDD21e/YlL923Ma4OIpyWsP0hy7gItBCPm5d7qIUW7Yo/cS2wo1qDdOhJaNlvlBD1lDou1fA==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.16.2.tgz",
+      "integrity": "sha512-vGFlrDKlmyI+BT+FemqVxmvO7nqxU33cgXVsn6IKAFishvlG3oV2Ds67D5nPkHMea8T+s1IcuMm0bF8ntZtAyg==",
       "license": "MIT",
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4"
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
       },
       "peerDependencies": {
         "react": "*",
@@ -17944,8 +17945,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -19132,13 +19132,15 @@
       }
     },
     "react-native-gesture-handler": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.27.1.tgz",
-      "integrity": "sha512-57TUWerhdz589OcDD21e/YlL923Ma4OIpyWsP0hy7gItBCPm5d7qIUW7Yo/cS2wo1qDdOhJaNlvlBD1lDou1fA==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.16.2.tgz",
+      "integrity": "sha512-vGFlrDKlmyI+BT+FemqVxmvO7nqxU33cgXVsn6IKAFishvlG3oV2Ds67D5nPkHMea8T+s1IcuMm0bF8ntZtAyg==",
       "requires": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4"
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
       }
     },
     "react-native-is-edge-to-edge": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@react-navigation/native": "^7.1.14",
     "react": "18.2.0",
     "react-native": "0.73.6",
-    "react-native-gesture-handler": "^2.27.1",
+    "react-native-gesture-handler": "~2.16.0",
     "react-native-reanimated": "~3.6.2",
     "react-native-safe-area-context": "^5.5.1",
     "react-native-screens": "^4.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5668,7 +5668,7 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.8.1:
+prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -5759,14 +5759,16 @@ react-native-drawer-layout@^4.1.11:
   dependencies:
     use-latest-callback "^0.2.4"
 
-react-native-gesture-handler@^2.27.1, "react-native-gesture-handler@>= 2.0.0":
-  version "2.27.1"
-  resolved "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.27.1.tgz"
-  integrity sha512-57TUWerhdz589OcDD21e/YlL923Ma4OIpyWsP0hy7gItBCPm5d7qIUW7Yo/cS2wo1qDdOhJaNlvlBD1lDou1fA==
+"react-native-gesture-handler@>= 2.0.0", react-native-gesture-handler@~2.16.0:
+  version "2.16.2"
+  resolved "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.16.2.tgz"
+  integrity sha512-vGFlrDKlmyI+BT+FemqVxmvO7nqxU33cgXVsn6IKAFishvlG3oV2Ds67D5nPkHMea8T+s1IcuMm0bF8ntZtAyg==
   dependencies:
     "@egjs/hammerjs" "^2.0.17"
     hoist-non-react-statics "^3.3.0"
     invariant "^2.2.4"
+    lodash "^4.17.21"
+    prop-types "^15.7.2"
 
 react-native-is-edge-to-edge@^1.1.7:
   version "1.1.7"


### PR DESCRIPTION
- Downgraded react-native-gesture-handler from ^2.27.1 to ~2.16.0.
- This is an attempt to resolve Android build failures related to Kotlin compilation and classpath issues, potentially caused by incompatibilities between the newer gesture-handler version and the project's React Native version (0.73.6) or Kotlin setup.