### PR TITLE
fix: Downgrade react-native-safe-area-context to ~4.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "react-native": "0.73.6",
         "react-native-gesture-handler": "~2.16.0",
         "react-native-reanimated": "~3.6.2",
-        "react-native-safe-area-context": "^5.5.1",
+        "react-native-safe-area-context": "~4.8.2",
         "react-native-screens": "^4.11.1"
       },
       "devDependencies": {
@@ -10171,9 +10171,9 @@
       }
     },
     "node_modules/react-native-safe-area-context": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.5.1.tgz",
-      "integrity": "sha512-WYxV+mm7SWuapVWxq2071lkQlDUXjSwcu7Cc2bUtNcF80/Bl0WnuWAZ8+tO46M38PclMrQIIgbv83BvDHJNQ5g==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.8.2.tgz",
+      "integrity": "sha512-ffUOv8BJQ6RqO3nLml5gxJ6ab3EestPiyWekxdzO/1MQ7NF8fW1Mzh1C5QE9yq573Xefnc7FuzGXjtesZGv7cQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",
@@ -19161,9 +19161,9 @@
       }
     },
     "react-native-safe-area-context": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.5.1.tgz",
-      "integrity": "sha512-WYxV+mm7SWuapVWxq2071lkQlDUXjSwcu7Cc2bUtNcF80/Bl0WnuWAZ8+tO46M38PclMrQIIgbv83BvDHJNQ5g==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.8.2.tgz",
+      "integrity": "sha512-ffUOv8BJQ6RqO3nLml5gxJ6ab3EestPiyWekxdzO/1MQ7NF8fW1Mzh1C5QE9yq573Xefnc7FuzGXjtesZGv7cQ==",
       "requires": {}
     },
     "react-native-screens": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-native": "0.73.6",
     "react-native-gesture-handler": "~2.16.0",
     "react-native-reanimated": "~3.6.2",
-    "react-native-safe-area-context": "^5.5.1",
+    "react-native-safe-area-context": "~4.8.2",
     "react-native-screens": "^4.11.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5785,10 +5785,10 @@ react-native-is-edge-to-edge@^1.1.7:
     convert-source-map "^2.0.0"
     invariant "^2.2.4"
 
-react-native-safe-area-context@^5.5.1, "react-native-safe-area-context@>= 4.0.0":
-  version "5.5.1"
-  resolved "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.5.1.tgz"
-  integrity sha512-WYxV+mm7SWuapVWxq2071lkQlDUXjSwcu7Cc2bUtNcF80/Bl0WnuWAZ8+tO46M38PclMrQIIgbv83BvDHJNQ5g==
+"react-native-safe-area-context@>= 4.0.0", react-native-safe-area-context@~4.8.2:
+  version "4.8.2"
+  resolved "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.8.2.tgz"
+  integrity sha512-ffUOv8BJQ6RqO3nLml5gxJ6ab3EestPiyWekxdzO/1MQ7NF8fW1Mzh1C5QE9yq573Xefnc7FuzGXjtesZGv7cQ==
 
 react-native-screens@^4.11.1, "react-native-screens@>= 4.0.0":
   version "4.11.1"


### PR DESCRIPTION
- Downgraded react-native-safe-area-context from ^5.5.1 to ~4.8.2.
- This is an attempt to resolve Android build failures related to Kotlin compilation and unresolved references (e.g., BaseReactPackage), likely caused by incompatibilities between the newer safe-area-context version and the project's React Native version (0.73.6).