### PR TITLE
CI: Log patched files content

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -22,6 +22,15 @@ jobs:
         run: |
           npm install
 
+      - name: Verify Patched Files
+        run: |
+          echo "--- Contents of react-native-screens/android/build.gradle ---"
+          cat node_modules/react-native-screens/android/build.gradle || echo "File not found: node_modules/react-native-screens/android/build.gradle"
+          echo "--- End of react-native-screens/android/build.gradle ---"
+          echo "--- Contents of RNScreensPackage.kt ---"
+          cat node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/RNScreensPackage.kt || echo "File not found: node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/RNScreensPackage.kt"
+          echo "--- End of RNScreensPackage.kt ---"
+
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 


### PR DESCRIPTION
Add a step to the GitHub Actions workflow to cat the contents of react-native-screens's build.gradle and RNScreensPackage.kt after npm install to verify if patches are being applied.