### PR TITLE
Fix: Specify AGP version and ensure Kotlin plugin uses ext variable

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,9 +12,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle")
+        classpath("com.android.tools.build:gradle:8.2.1") // Spécifier explicitement la version AGP
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion") // Utiliser la variable kotlinVersion
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "MonJeu",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "dependencies": {
         "@react-navigation/drawer": "^7.5.2",
         "@react-navigation/native": "^7.1.14",


### PR DESCRIPTION
Explicitly set the Android Gradle Plugin version to 8.2.1 in `android/build.gradle`. Ensured that the Kotlin Gradle Plugin uses the `kotlinVersion` eXt variable.

These changes aim to stabilize the Android build configuration and are standard practices for React Native 0.73.x projects.

Note: The build is currently failing due to an SDK location issue in the environment, which prevents full validation of these changes against the original Kotlin compilation error for `react-native-screens`.