### PR TITLE
Enable GitHub Pages deployment for web version

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,34 @@
+name: Deploy to GitHub Pages
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight UTC
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js ⚙️
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install and Build 🔧
+        run: |
+          npm install --legacy-peer-deps
+          npm run build:web
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dist # The folder the action should deploy.
+          branch: gh-pages # The branch the action should deploy to.

--- a/index.web.js
+++ b/index.web.js
@@ -1,0 +1,13 @@
+import 'react-native-gesture-handler';
+import { AppRegistry } from 'react-native';
+import App from './App';
+import { name as appName } from './app.json';
+
+// Register the app
+AppRegistry.registerComponent(appName, () => App);
+
+// Run the app
+AppRegistry.runApplication(appName, {
+  initialProps: {},
+  rootTag: document.getElementById('root'),
+});

--- a/package.json
+++ b/package.json
@@ -7,20 +7,24 @@
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "start": "react-native start",
-    "test": "jest"
+    "test": "jest",
+    "build:web": "webpack --mode production --config webpack.config.js"
   },
   "dependencies": {
     "@react-navigation/native": "^7.1.14",
     "@react-navigation/stack": "^7.4.2",
     "react": "18.2.0",
+    "react-dom": "18.2.0",
     "react-native": "0.73.6",
     "react-native-gesture-handler": "2.14.0",
     "react-native-reanimated": "3.6.2",
     "react-native-safe-area-context": "4.8.2",
-    "react-native-screens": "^4.11.1"
+    "react-native-screens": "^4.11.1",
+    "react-native-web": "0.19.10"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
+    "@babel/preset-react": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
     "@react-native/babel-preset": "0.73.21",
@@ -30,11 +34,20 @@
     "@types/react": "^18.2.6",
     "@types/react-test-renderer": "^18.0.0",
     "babel-jest": "^29.6.3",
+    "babel-loader": "^9.1.3",
+    "babel-plugin-react-native-web": "^0.19.10",
+    "css-loader": "^6.8.1",
     "eslint": "^8.19.0",
+    "html-webpack-plugin": "^5.5.3",
     "jest": "^29.6.3",
     "prettier": "2.8.8",
     "react-test-renderer": "18.2.0",
-    "typescript": "5.0.4"
+    "style-loader": "^3.3.3",
+    "typescript": "5.0.4",
+    "url-loader": "^4.1.1",
+    "webpack": "^5.88.2",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
   },
   "engines": {
     "node": ">=18"

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MonJeu - Web</title>
+    <style>
+        html, body, #root {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+            overflow: hidden;
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+</body>
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,97 @@
+const path = require('path');
+const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const appDirectory = __dirname;
+
+const babelLoaderConfiguration = {
+  test: /\.js$/,
+  // Add every directory that needs to be compiled by Babel during the build.
+  include: [
+    path.resolve(appDirectory, 'index.web.js'),
+    path.resolve(appDirectory, 'src'),
+    path.resolve(appDirectory, 'App.js'),
+    path.resolve(appDirectory, 'node_modules/react-native-reanimated'),
+    path.resolve(appDirectory, 'node_modules/react-native-gesture-handler'),
+    path.resolve(appDirectory, 'node_modules/react-native-screens'),
+    path.resolve(appDirectory, 'node_modules/react-native-safe-area-context'),
+    path.resolve(appDirectory, 'node_modules/@react-navigation'),
+  ],
+  use: {
+    loader: 'babel-loader',
+    options: {
+      cacheDirectory: true,
+      // The 'metro-react-native-babel-preset' preset is recommended to match React Native's packager
+      presets: ['module:@react-native/babel-preset', '@babel/preset-react'],
+      // Re-write import statements to use the web-specific version of the library
+      plugins: ['react-native-web', 'react-native-reanimated/plugin'],
+    },
+  },
+};
+
+// This is needed for webpack to import static images in JavaScript files.
+const imageLoaderConfiguration = {
+  test: /\.(gif|jpe?g|png|svg)$/,
+  use: {
+    loader: 'url-loader',
+    options: {
+      name: '[name].[ext]',
+      esModule: false,
+    },
+  },
+};
+
+const cssLoaderConfiguration = {
+  test: /\.css$/,
+  use: ['style-loader', 'css-loader'],
+};
+
+module.exports = {
+  entry: [
+    // load any polyfills or collections that your app needs,
+    // e.g. 'babel-polyfill',
+    path.resolve(appDirectory, 'index.web.js'),
+  ],
+
+  // configures where the build ends up
+  output: {
+    filename: 'bundle.web.js',
+    path: path.resolve(appDirectory, 'dist'),
+  },
+
+  module: {
+    rules: [
+      babelLoaderConfiguration,
+      imageLoaderConfiguration,
+      cssLoaderConfiguration,
+    ],
+  },
+
+  resolve: {
+    // This will map the 'react-native' package to 'react-native-web'.
+    alias: {
+      'react-native$': 'react-native-web',
+    },
+    // If you're working on a multi-platform project, web.js or web.tsx
+    // can be used to help separate web-specific logic from native-specific logic.
+    extensions: ['.web.js', '.js'],
+  },
+
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: path.resolve(appDirectory, 'public/index.html'),
+    }),
+    new webpack.DefinePlugin({
+      // The variable below is needed for 'react-native-web'
+      __DEV__: JSON.stringify(process.env.NODE_ENV !== 'production'),
+    }),
+  ],
+
+  devServer: {
+    historyApiFallback: true,
+    static: {
+      directory: path.join(__dirname, 'public'),
+    },
+    hot: true,
+  },
+};


### PR DESCRIPTION
I have transformed the React Native game into a web application and set up an automated deployment pipeline to GitHub Pages.

Key changes:
1.  **Web Support**: Added `react-native-web` and configured Webpack to alias `react-native` to `react-native-web`.
2.  **Entry Points**: Created `index.web.js` and `public/index.html` to initialize the application in a web environment.
3.  **CI/CD**: Added a GitHub Action workflow in `.github/workflows/deploy-web.yml` that:
    *   Triggers manually (`workflow_dispatch`) and once daily at midnight UTC (`schedule`).
    *   Builds the web version using Webpack.
    *   Deploys the static files to the `gh-pages` branch.
4.  **Compatibility**: Updated the configuration to handle native dependencies (reanimated, navigation, etc.) on the web and included `react-native-gesture-handler` initialization.

Note: Per `AGENTS.MD`, `package-lock.json` was not modified. The deployment workflow uses `--legacy-peer-deps` to handle dependency conflicts in the CI environment.

---
*PR created automatically by Jules for task [10056757145848375488](https://jules.google.com/task/10056757145848375488) started by @XiaoRaph*